### PR TITLE
Add twin.macro

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,5 +10,10 @@
     "@babel/preset-react",
     "@babel/preset-typescript"
   ],
-  "plugins": ["@babel/plugin-transform-runtime"]
+  "plugins": [
+    "@babel/plugin-transform-runtime",
+    ["babel-plugin-twin", { "debug": false }],
+    "babel-plugin-macros",
+    ["babel-plugin-styled-components", { "ssr": true }]
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -14,6 +14,6 @@
     "@babel/plugin-transform-runtime",
     ["babel-plugin-twin", { "debug": false }],
     "babel-plugin-macros",
-    ["babel-plugin-styled-components", { "ssr": true }]
+    ["babel-plugin-styled-components"]
   ]
 }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,15 @@ yarn prerelease
 
 2. Make sure that semantic version you want for release is correctly interpreted by the lib in terms of `major.minor.patch`.
 
-**Prerelease (Semi Automated)** (Create a alpha prerelease version) 3. You have determined with dry run what the version looks like. Now you can run the release script `yarn prerelease` to create alpha version to this release. 4. The above script also commits the new version, creates git tag for this release. 5. Push the commits and tags using the command: `git push --follow-tags` 6. Put the alpha version of component lib to use and test before the final release.
+**Prerelease (Semi Automated)** (Create a alpha prerelease version)
+
+3. You have determined with dry run what the version looks like. Now you can run the release script `yarn prerelease` to create alpha version to this release.
+
+4. The above script also commits the new version, creates git tag for this release.
+
+5. Push the commits and tags using the command: `git push --follow-tags`
+
+6. Put the alpha version of component lib to use and test before the final release.
 
 **Release (Semi Automated)** (Create a release version) 7. Run the script `yarn release`, to create a release from the alpha version. eg Prerelease alpha version `v0.0.2-alpha.0` to official release`v0.0.2` 8. The above script also commits the new version, creates git tag for this release. 9. Push the commits and tags using the command: `git push --follow-tags` 10. Create Github Release
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This module exports all of the components and types defined for the components.
 - Jest DOM - utility package for React Testing Library, providing custom matchers to write reliable tests
 - TS Jest - TypeScript pre-processor to allow Jest to consume and typecheck tests
 - Rollup, and Babel - bundle the application for distribution
+- twin.macro - apply Tailwind CSS styles to styled-components styles
 
 ### Storybook
 
@@ -55,7 +56,7 @@ With Tailwind. The repo uses:
 - tailwind.config.js file at the root. You can use this to customize your Tailwind theme and add overrides. If you want to add your own theme colors and classes you can read more about that on [Tailwind’s theme documentation](https://tailwindcss.com/docs/theme).
 - Tailwaind Just In Time (JIT) mode to make development faster.
 - Purge paths to the config. This is so Tailwind can look through the specified files and only add the css classes that are being used.
-- A `build` script that includes the Tailwind build (when building, a `tailwind.css` file will be included in `dist`).
+- twin.macro uses the Tailwind config (see `babelMacros`, in package.json).
 
 ### Code Style and Quality
 
@@ -79,7 +80,7 @@ Generate component: `yarn generate:component Thing --type atom` (or `pattern` / 
 
 `yarn build`
 The repo uses Babel and Rollup for the build configuration.
-Rollup will create distribution artifacts. Tailwind will also create a minified CSS file when the build is run. TypeScript Declarations are included in the distribution (configured via `tsconfig.build.json`).
+Rollup will create distribution artifacts. TypeScript Declarations are included in the distribution (configured via `tsconfig.build.json`).
 
 #### Babel
 
@@ -95,7 +96,8 @@ npx browserslist ">0.2%, not dead, not op_mini all"
 
 The repo includes several development dependencies for Babel. It also includes a standard dependency `@babel/runtime` to share helper functions that would otherwise be duplicated when using the library.
 
-###  Release management
+### Release management
+
 1. We are using [commitizen](https://github.com/commitizen/cz-cli) to standardize our commits.
 
 2. We are using [standard-version](https://github.com/conventional-changelog/standard-version) for semantic versioning. We have 3 scripts created to achieve the release for our project:
@@ -111,7 +113,7 @@ yarn prerelease
 
 `yarn release`
 
-####  Overall steps for versioning that we are looking at in the scripts are as follows:
+#### Overall steps for versioning that we are looking at in the scripts are as follows:
 
 1.  **SKIPPING Changelog**: By default, prerelease is created with changelogs. But for this project we would use skip creating changelogs and use [Github Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) for generating changelogs and release notes.
 
@@ -125,24 +127,21 @@ yarn prerelease
 
 6.  **Push changes and tags** Run command in terminal `git push --follow-tags` to publish
 
-####  Below is the step by step process when working on a release
+#### Below is the step by step process when working on a release
 
 **Prerelease, dry run**
+
 1. Create a prerelease with dry run using the script `yarn prerelease:dry-run`.
 
 2. Make sure that semantic version you want for release is correctly interpreted by the lib in terms of `major.minor.patch`.
 
-**Prerelease (Semi Automated)** (Create a alpha prerelease version)
-3. You have determined with dry run what the version looks like. Now you can run the release script `yarn prerelease` to create alpha version to this release.
-4. The above script also commits the new version, creates git tag for this release.
-5. Push the commits and tags using the command: `git push --follow-tags`
-6. Put the alpha version of component lib to use and test before the final release.
+**Prerelease (Semi Automated)** (Create a alpha prerelease version) 3. You have determined with dry run what the version looks like. Now you can run the release script `yarn prerelease` to create alpha version to this release. 4. The above script also commits the new version, creates git tag for this release. 5. Push the commits and tags using the command: `git push --follow-tags` 6. Put the alpha version of component lib to use and test before the final release.
 
 **Release (Semi Automated)** (Create a release version) 7. Run the script `yarn release`, to create a release from the alpha version. eg Prerelease alpha version `v0.0.2-alpha.0` to official release`v0.0.2` 8. The above script also commits the new version, creates git tag for this release. 9. Push the commits and tags using the command: `git push --follow-tags` 10. Create Github Release
 
-####  Github Release
+#### Github Release
 
-For this project we are using GitHub Releases, a feature of the GitHub platform that allows developers to publish the software release. The distribution is restricted to be read only access to other repos. 
+For this project we are using GitHub Releases, a feature of the GitHub platform that allows developers to publish the software release. The distribution is restricted to be read only access to other repos.
 
 1. On GitHub.com, navigate to the main page of the repository.
 2. To the right of the list of files, click Releases.
@@ -155,7 +154,7 @@ For this project we are using GitHub Releases, a feature of the GitHub platform 
 9. PAT (Personal Access Token - Fine grained) needs to be setup to use the release in other projects.
 10. Create the PAT with time limit of 6 months and provide the read only access to `Contents`. When the token expires follow the steps [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-fine-grained-personal-access-token) to generate a new personal access token (fine-grained)
 11. Generate PAT & add it to a .npmrc file when deploying the release. (.npmrc will be gitignored)
-12. Try using this release version in one of your projects to ensure the latest changes are available to use. 
+12. Try using this release version in one of your projects to ensure the latest changes are available to use.
 
 ### Troubleshooting and solutions
 

--- a/README.md
+++ b/README.md
@@ -161,3 +161,7 @@ For this project we are using GitHub Releases, a feature of the GitHub platform 
 #### Storybook
 
 Typescript 5.+ (used by this project) has dropped several methods expected for use by the current stable version of Storybook (6.+), which was preventing Storybook from building. A workaround has been put in place within package.json, as described [here](hipstersmoothie/react-docgen-typescript-plugin#78). This is a work around, which maybe not be applicable soon, if storybook republishes their version to not use @storybook/react-docgen-typescript-plugin.
+
+#### twin.macro
+
+There are [several examples here](https://github.com/ben-rogerson/twin.examples) which may be useful if troubleshooting issues related to twin.macro.

--- a/_templates/component/new/component.styles.ejs.t
+++ b/_templates/component/new/component.styles.ejs.t
@@ -1,0 +1,8 @@
+---
+to: src/<%= h.getTypePath(locals.type) %>/<%=name%>/<%=name%>.styles.tsx
+# Lint only the generated file
+sh: yarn lint:fix <%= h.getBasePath() %><%= h.getTypePath(locals.type) %>/<%=name%>/<%=name%>.styles.tsx
+---
+
+import styled from 'styled-components';
+import tw from 'twin.macro';

--- a/_templates/component/new/component.test.ejs.t
+++ b/_templates/component/new/component.test.ejs.t
@@ -6,6 +6,8 @@ sh: yarn lint:fix <%= h.getBasePath() %><%= h.getTypePath(locals.type) %>/<%=nam
 import React from 'react'
 import { render } from '@testing-library/react'
 import { Default } from './<%= name %>.stories'
+import { ThemeProvider } from 'styled-components';
+import { lightTheme, darkTheme } from '../../themes/index';
 
 describe('<%= name %>', () => {
   it('renders as expected', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,14 @@ module.exports = {
   preset: 'ts-jest',
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: './tsconfig.json',
+        babelConfig: './.babelrc',
+        useESM: true,
+      },
+    ],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-node-externals": "^5.1.2",
     "standard-version": "^9.5.0",
-    "tailwindcss": "^3.2.7",
+    "tailwindcss": "^3.3.1",
     "ts-jest": "^29.0.5",
     "typescript": "^5.0.2"
   },
@@ -95,6 +95,9 @@
     "@storybook/manager-webpack5": "^6.5.16",
     "@storybook/preset-typescript": "^3.0.0",
     "babel-plugin-macros": "^3.1.0",
-    "styled-components": "^5.3.9"
+    "babel-plugin-styled-components": "^2.1.1",
+    "babel-plugin-twin": "^1.1.0",
+    "styled-components": "^5.3.9",
+    "twin.macro": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/typings/index.d.ts",
   "repository": "git@github.com:whitelabelco/whitelabel-components.git",
   "author": "SimonN <65023744+s994n@users.noreply.github.com>",
-  "license": "\"UNLICENSED\"",
+  "license": "UNLICENSED",
   "private": false,
   "peerDependencies": {
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -79,10 +79,9 @@
     "lint": "eslint src/**/*",
     "lint:fix": "eslint src/**/* --fix",
     "generate:component": "npx hygen component new",
-    "build-tailwind": "npx tailwindcss -o ./dist/tailwind.css --minify",
     "build:js": "rollup -c rollup.config.js --bundleConfigAsCjs",
     "build:types": "tsc -p tsconfig.build.json",
-    "build": "yarn run build:js && yarn run build:types && yarn build-tailwind",
+    "build": "yarn run build:js && yarn run build:types",
     "commit": "cz",
     "prerelease:dry-run": "standard-version --skip.changelog --prerelease alpha --dry-run",
     "prerelease": "standard-version --skip.changelog --prerelease alpha",
@@ -99,5 +98,12 @@
     "babel-plugin-twin": "^1.1.0",
     "styled-components": "^5.3.9",
     "twin.macro": "^3.3.0"
+  },
+  "babelMacros": {
+    "twin": {
+      "preset": "styled-components",
+      "styled": "styled-components",
+      "config": "./tailwind.config.js"
+    }
   }
 }

--- a/src/atoms/Button/Button.styles.tsx
+++ b/src/atoms/Button/Button.styles.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import tw from 'twin.macro';
 
 const sharedButtonStyling = styled.button`
   padding: 0.75em 1em;
@@ -38,4 +39,8 @@ export const StyledButtonThree = styled(sharedButtonStyling)`
 
   border-radius: ${({ theme }) => theme.borderRadius.large};
   border: 1px ${({ theme }) => theme.colors.disabledBorder} solid;
+`;
+
+export const TwButton = styled.button`
+  ${tw`bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded`}
 `;

--- a/src/atoms/Button/Button.tsx
+++ b/src/atoms/Button/Button.tsx
@@ -6,7 +6,6 @@ import {
   StyledButtonThree,
   TwButton,
 } from './Button.styles';
-import tw from 'twin.macro';
 
 export interface ButtonProps {
   name: string;

--- a/src/atoms/Button/Button.tsx
+++ b/src/atoms/Button/Button.tsx
@@ -4,6 +4,7 @@ import {
   StyledButtonOne,
   StyledButtonTwo,
   StyledButtonThree,
+  TwButton,
 } from './Button.styles';
 
 export interface ButtonProps {
@@ -56,6 +57,7 @@ export const Button = forwardRef<Ref, ComponentPropsWithoutRef<'button'>>(
       <TestText>Text test</TestText>
       <TestSubText>Subtext test</TestSubText>
       <TextLink href={'https://whitelabelco.com/blog'}>Link test</TextLink>
+      <TwButton>This is a twin.macro-styled button</TwButton>
     </CardExample>
   ),
 );

--- a/src/atoms/Button/Button.tsx
+++ b/src/atoms/Button/Button.tsx
@@ -6,6 +6,7 @@ import {
   StyledButtonThree,
   TwButton,
 } from './Button.styles';
+import tw from 'twin.macro';
 
 export interface ButtonProps {
   name: string;

--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -3,38 +3,38 @@
 exports[`Button renders as expected 1`] = `
 <div>
   <div
-    class="sc-eDDNvR bvpcpn"
+    class="Button__CardExample-sc-1aocd7z-0 fgjxid"
   >
     <button
-      class="sc-beqWaB sc-gueYoa eEsySp bQDNlw"
+      class="Buttonstyles__sharedButtonStyling-sc-iaqf7v-0 Buttonstyles__StyledButtonOne-sc-iaqf7v-1 lczdqw ebxeau"
       type="button"
     >
       test
     </button>
     <button
-      class="sc-beqWaB sc-dmqHEX eEsySp hQIzWf"
+      class="Buttonstyles__sharedButtonStyling-sc-iaqf7v-0 Buttonstyles__StyledButtonTwo-sc-iaqf7v-2 lczdqw xXUiV"
       type="button"
     >
       test
     </button>
     <button
-      class="sc-beqWaB sc-hLseeU eEsySp ipqFhF"
+      class="Buttonstyles__sharedButtonStyling-sc-iaqf7v-0 Buttonstyles__StyledButtonThree-sc-iaqf7v-3 lczdqw igOyGn"
       type="button"
     >
       test
     </button>
     <p
-      class="sc-jTrPJq gvqEYd"
+      class="Button__TestText-sc-1aocd7z-1 kwKoEh"
     >
       Text test
     </p>
     <p
-      class="sc-gLDzan cVPCEA"
+      class="Button__TestSubText-sc-1aocd7z-2 cyjOwK"
     >
       Subtext test
     </p>
     <a
-      class="sc-iAEyYk jmcIIf"
+      class="Button__TextLink-sc-1aocd7z-3 bxqyim"
       href="https://whitelabelco.com/blog"
     >
       Link test

--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -39,6 +39,11 @@ exports[`Button renders as expected 1`] = `
     >
       Link test
     </a>
+    <button
+      class="Buttonstyles__TwButton-sc-iaqf7v-4 bWciPT"
+    >
+      This is a twin.macro-styled button
+    </button>
   </div>
 </div>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,7 +1126,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/template@^7.12.7", "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
+"@babel/template@^7.12.13", "@babel/template@^7.12.7", "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
   integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
@@ -4425,7 +4425,7 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-"babel-plugin-styled-components@>= 1.12.0":
+"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.1.tgz#cd977cc0ff8410d5cbfdd142e42576e9c8794b87"
   integrity sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==
@@ -4440,6 +4440,13 @@ babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==
+
+babel-plugin-twin@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-twin/-/babel-plugin-twin-1.1.0.tgz#fa2e9d94c22ed8bf2649fb7db508b9141e8cbb50"
+  integrity sha512-x4AZ7JSh8MmC6uEN41nrU021jLA0B4E1UD7AI0KJOtAwvTH1wEMLugW5SyY4m/CWDtsqZc1fqT1lkDoO2rdmHg==
+  dependencies:
+    "@babel/template" "^7.12.13"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
@@ -4965,6 +4972,14 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -4978,14 +4993,6 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -6287,6 +6294,13 @@ electron-to-chromium@^1.4.284:
   version "1.4.360"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.360.tgz#7a24cf81588d6af82ab17d77715cdc09dacfafb2"
   integrity sha512-EP/jdF15S+l3iSSzgUpUqeazvkbVFXNuVxwwLMVUSie3lUeH1HH70gKe0IS7TASB/0h5QPG2bLMzv2jelSztIQ==
+
+element-resize-detector@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.2.4.tgz#3e6c5982dd77508b5fa7e6d5c02170e26325c9b1"
+  integrity sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==
+  dependencies:
+    batch-processor "1.0.0"
 
 element-resize-detector@^1.2.2:
   version "1.2.4"
@@ -9453,6 +9467,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -12634,7 +12653,7 @@ synchronous-promise@^2.0.15:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.17.tgz#38901319632f946c982152586f2caf8ddc25c032"
   integrity sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==
 
-tailwindcss@^3.2.7:
+tailwindcss@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.1.tgz#b6662fab6a9b704779e48d083a9fef5a81d2b81e"
   integrity sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==
@@ -13000,6 +13019,18 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==
+
+twin.macro@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/twin.macro/-/twin.macro-3.3.0.tgz#f8e1b73d87de95bf3cc8b2809289754a85fa820c"
+  integrity sha512-74KJWNejkDhzVQnJ4tf54bEdkhvc/FpHtF3xm/pnR9KtK78+kuPpc+A6zwcBctOe3Yr1+bYGrYVMKMU1x0C/Eg==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    babel-plugin-macros "^3.1.0"
+    chalk "4.1.2"
+    lodash.get "^4.4.2"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "^6.0.10"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
<!--- ^^ Add Descriptive title above ^^ 

Note: Use sentences. CamelCase is used for easy double-click selection
Reference: Link to blog post coming soon :raised_hands:

Link to Issue/Ticket -->
Resolves: Issue #9 

## Description
This PR:
* Add twin.macro and configuration to work with styled-components
* Add throw-away example within the Button component, using twin.macro for styling
* Remove tailwind.css file from build output (see extra notes)
* Update hygen-generated files to include styles file for a new component 

## To Test :mag: 
* If needed follow setup instructions in the README
* Run `yarn` to install packages
* Start storybook: `yarn storybook`
	* You should see this button included in the Button-Default story
![Screenshot 2023-04-13 at 12 35 06](https://user-images.githubusercontent.com/65023744/231760214-b46c6692-52dc-42c6-ad44-a0c3a9db79e3.png)
* Run tests with Jest:
	* Note: you may need to clear your Jest cache: `npx jest --clearCache`
	* Run `yarn test`
* Build the library: `yarn build`
	* You should see the dist folder created, like this:
	
![Screenshot 2023-04-13 at 12 40 39](https://user-images.githubusercontent.com/65023744/231760268-9a47e18a-ab07-4485-b2f7-42a8ab8a537a.png)

<!-- Don't edit checklist. This is for you to do. -->
## Checklist :white_check_mark:
- [x] I have looked over the diffs.
- [x] There are no errors/failing tests from my changes on this branch.
- [x] I have requested a review on this PR.
~~I have re-assigned the Github ticket and moved the ticket on the project board.~~
~~If I have added an ENV var or other secrets, I have updated Dashlane and the ReadMe (and any other applicable docs)~~

## Additional Details and Screenshots :art: <!-- If applicable -->
* re Removal of tailwind.css from build. My current understanding is that this is no longer needed (and possibly determental to include) now that we’re using twin.macro (the CSS from twin.macro should go in the built component file); however, if we need it for some reason later on then we could add back the commands to include tailwind.css in the build.
* this PR doesn’t include changes from branch `setup/11/theme-built-testing-build`, which will be needed for working through issues related to using the component lib as a dependency — I’m aiming to address this in a separate PR